### PR TITLE
add Leichte-Sprache-Variante mit Sprachschalter im Header

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,8 @@
 baseURL = "https://www.c3re.de"
-languageCode = "de-de"
 title = "c3RE"
 theme = "hugo-theme-flat"
 defaultContentLanguage = "de"
+defaultContentLanguageInSubdir = false
 relativeURLs = true
 style = "green"
 
@@ -13,44 +13,71 @@ mainSections = ["."]
 [pagination]
 pagerSize = 4
 
-[[menus.main]]
-name = "Philosophie"
-url = "/unsere-philosophie"
+# ---------------------------------------------------------------------------
+# Sprachen: Standard-Deutsch und "Leichte Sprache" (Barrierefreiheit gemäß
+# BFSG / EAA). Inhalte der Leichten Sprache liegen als Dateien mit Suffix
+# ".de-leicht.md" neben den Standardseiten (z. B. _index.de-leicht.md).
+# ---------------------------------------------------------------------------
 
-[[menus.main]]
-name = "Unvereinbarkeitserklärung"
-url = "/unvereinbarkeitserklaerung"
+[languages]
+  [languages.de]
+    languageCode = "de-DE"
+    languageName = "Standard-Sprache"
+    weight = 1
+    title = "c3RE"
 
-[[menus.main]]
-name = "Codeweek"
-url = "/codeweek"
+    [[languages.de.menus.main]]
+    name = "Philosophie"
+    url = "/unsere-philosophie"
 
-# [[menus.main]]
-# name = "News"
-# url = "/news/"
-# weight = 80
+    [[languages.de.menus.main]]
+    name = "Unvereinbarkeitserklärung"
+    url = "/unvereinbarkeitserklaerung"
 
-[[menus.main]]
-name = "Werkzeuge"
-url = "https://dienste.c3re.de/"
-weight = 90
+    [[languages.de.menus.main]]
+    name = "Codeweek"
+    url = "/codeweek"
 
-[[menus.main]]
-name = "Downloads"
-url = "/downloads/"
-weight = 110
-[[menus.main]]
-name = "Kontakt"
-url = "/kontakt/"
-weight = 110
+    [[languages.de.menus.main]]
+    name = "Werkzeuge"
+    url = "https://dienste.c3re.de/"
+    weight = 90
 
-# Footer Menue
+    [[languages.de.menus.main]]
+    name = "Downloads"
+    url = "/downloads/"
+    weight = 110
+
+    [[languages.de.menus.main]]
+    name = "Kontakt"
+    url = "/kontakt/"
+    weight = 110
+
+  [languages.de-leicht]
+    languageCode = "de-DE"
+    languageName = "Leichte Sprache"
+    weight = 2
+    title = "c3RE – in Leichter Sprache"
+
+    [[languages.de-leicht.menus.main]]
+    name = "Über uns"
+    url = "/unsere-philosophie/"
+    weight = 10
+
+    [[languages.de-leicht.menus.main]]
+    name = "Kontakt"
+    url = "/kontakt/"
+    weight = 20
+
+# ---------------------------------------------------------------------------
+# Footer-Menü
+# ---------------------------------------------------------------------------
+
 [[params.footer_rows]]
 [[params.footer_rows.items]]
 name = "Kontakt"
 url = "/kontakt"
 
-#[[params.footer_rows]]
 [[params.footer_rows.items]]
 name = "Impressum"
 url = "/impressum"

--- a/content/_index.de-leicht.md
+++ b/content/_index.de-leicht.md
@@ -1,0 +1,71 @@
+---
+title: "Willkommen beim c3RE"
+date:
+tags: []
+categories: []
+weight: 50
+show_comments: false
+katex: false
+draft: false
+description: "Start-Seite vom c3RE in Leichter Sprache."
+---
+
+Diese Seite ist in **Leichter Sprache**.
+
+Leichte Sprache hilft vielen Menschen.
+Zum Beispiel:
+
+- Menschen mit Lern-Schwierigkeiten.
+- Menschen, die nicht so gut Deutsch können.
+- Menschen, die nicht so gut lesen können.
+
+## Wer sind wir?
+
+Wir sind der **c3RE**.
+
+Das spricht man so: „Ze drei Er Ee“.
+
+c3RE ist die Abkürzung für: **Chaos-Treff im Kreis Recklinghausen**.
+
+Wir sind ein **Verein**.
+Ein Verein ist eine Gruppe von Menschen.
+Die Menschen haben das gleiche Hobby.
+Unser Hobby ist: **Technik und Computer**.
+
+## Was machen wir?
+
+Wir treffen uns jeden **Mittwoch**.
+Wir treffen uns ab **18 Uhr**.
+
+Wir treffen uns in unserem Hacker-Raum.
+Der Raum heißt: **Hacker-Hütte**.
+
+In der Hacker-Hütte machen wir viele Sachen:
+
+- Wir arbeiten an Computern.
+- Wir bauen Sachen aus Technik.
+- Wir löten kleine Geräte.
+- Wir sprechen über Technik.
+- Wir helfen uns gegen-seitig.
+
+## Wer darf mit-machen?
+
+**Alle Menschen dürfen mit-machen.**
+
+Du musst kein Profi sein.
+Du musst nichts mit-bringen.
+Du musst auch keinen Eintritt zahlen.
+
+Wir freuen uns über jeden Besuch.
+
+![Bild von der Hacker-Hütte](/img/hackerhuette_400.webp#center_sa)
+
+## Wie kommst du zu uns?
+
+Auf der Seite **Kontakt** steht:
+
+- Wo wir sind.
+- Wie du zu uns kommst.
+- Wie du uns erreichen kannst.
+
+![Bild von Captain Crunch](/img/crunch_400.webp#center_sa)

--- a/content/kontakt.de-leicht.md
+++ b/content/kontakt.de-leicht.md
@@ -1,0 +1,81 @@
+---
+title: "Kontakt"
+date:
+tags: []
+categories: []
+weight: 50
+show_comments: false
+katex: false
+draft: false
+description: "So erreichst du den c3RE. In Leichter Sprache."
+---
+
+Diese Seite ist in **Leichter Sprache**.
+
+## Komm einfach vorbei
+
+Du kannst uns gerne **besuchen**.
+
+Wir treffen uns jeden **Mittwoch**.
+Wir treffen uns ab **18 Uhr**.
+
+Du musst dich nicht an-melden.
+Du kannst einfach kommen.
+
+## Ist die Hütte gerade auf?
+
+Auf unserer Internet-Seite gibt es ein **Zeichen**.
+
+Das Zeichen zeigt:
+
+- **Grün:** Die Hütte ist auf. Du kannst kommen.
+- **Rot:** Die Hütte ist zu. Komm später wieder.
+
+## So erreichst du uns
+
+Du kannst uns eine **E-Mail** schreiben.
+
+Unsere E-Mail-Adresse ist:
+
+**kontakt(ät)c3re.de**
+
+Das (ät) ist ein Zeichen für **@**.
+Schreibe also: **kontakt@c3re.de**
+
+Du kannst uns auch **anrufen**.
+
+Unsere Telefon-Nummer ist:
+
+**02361 / 8488096**
+
+## Wo sind wir?
+
+Unsere Adresse ist:
+
+**Westcharweg 101**
+**45659 Recklinghausen**
+
+Wir sind in einer kleinen Hütte.
+Die Hütte ist auf einem alten Zechen-Gelände.
+
+Eine Zeche ist ein altes Berg-Werk.
+Früher haben dort Menschen Kohle aus der Erde geholt.
+
+### Mit dem Auto
+
+- Fahre zur Adresse oben.
+- Die Hütte liegt direkt an der Kreuzung von 2 großen Straßen.
+- Die Straßen heißen **B 225** und **A 43**.
+
+### Mit dem Bus
+
+Es gibt eine **Bus-Halte-Stelle** bei uns.
+Die Halte-Stelle heißt: **Westcharweg**.
+
+Diese Busse fahren zu uns:
+
+- Bus **214**
+- Bus **270**
+- Bus **NE 3**
+
+Vom Haupt-Bahnhof in Recklinghausen brauchst du **7 Minuten** mit dem Bus.

--- a/content/unsere-philosophie.de-leicht.md
+++ b/content/unsere-philosophie.de-leicht.md
@@ -1,0 +1,86 @@
+---
+title: "Über uns"
+date:
+tags: []
+categories: []
+weight: 50
+show_comments: false
+katex: false
+draft: false
+description: "Die Philosophie vom c3RE in Leichter Sprache."
+---
+
+Diese Seite ist in **Leichter Sprache**.
+
+## Was uns wichtig ist
+
+Computer sind heute fast überall.
+Computer steuern viele Sachen in unserem Leben.
+Aber nur wenige Menschen wissen genau:
+
+> Wie funktionieren Computer eigentlich?
+
+Wir wollen das **verstehen**.
+Wir wollen wissen:
+
+- Wie funktionieren Computer?
+- Wie funktioniert Technik?
+- Was kann man Gutes damit machen?
+- Was kann man Schlimmes damit machen?
+
+Wir lernen das gerne.
+Und wir helfen anderen Menschen beim Lernen.
+
+## Warum machen wir das?
+
+Wir machen das aus **drei Gründen**:
+
+1. Wir haben **Spaß** an Technik.
+2. Wir wollen **Neues lernen**.
+3. Wir wollen unsere **Freiheit schützen**.
+
+Manchmal benutzen Menschen Technik, um andere zu kontrollieren.
+Das wollen wir nicht.
+
+Wir wollen, dass alle Menschen frei sein können.
+
+## Wie gehen wir mit-einander um?
+
+Wir sagen oft einen wichtigen Satz:
+
+> **Sei nett zu anderen Menschen.**
+
+Auf Englisch heißt das:
+*Be excellent to each other.*
+
+Das gilt für alle Menschen bei uns.
+
+## Unsere Hacker-Regeln
+
+Hacker sind Menschen, die Technik gut verstehen.
+
+Wir Hacker haben **Regeln**.
+Die Regeln heißen: **Hacker-Ethik**.
+
+Hier sind die wichtigsten Regeln:
+
+- Alle Menschen sollen Computer benutzen dürfen.
+- Wissen soll für alle frei sein.
+- Glaube nicht alles, was Chefs und Politiker sagen.
+- Bewerte Menschen nach dem, was sie können.
+  Nicht nach Aussehen, Alter oder Geschlecht.
+- Mit Computern kann man schöne Sachen machen.
+- Computer können dein Leben besser machen.
+- Lösche keine fremden Daten.
+- Schütze die Daten von anderen Menschen.
+
+## Wo finde ich mehr?
+
+Die Hacker-Regeln in normaler Sprache findest du beim **Chaos Computer Club**.
+
+Der Chaos Computer Club ist eine **große Gruppe von Hackern in Deutschland**.
+
+Hier ist die Internet-Seite:
+[ccc.de/de/hackerethik](https://www.ccc.de/de/hackerethik)
+
+Diese Seite ist **nicht** in Leichter Sprache.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de"{{ if eq .Lang "de-leicht" }} data-leichte-sprache="true"{{ end }}>
+    <head>
+        {{ partial "head.html" . }}
+    </head>
+
+    <body{{ if eq .Lang "de-leicht" }} class="leichte-sprache"{{ end }}>
+        {{ partial "header.html" . }}
+        <main class="main-wrapper">
+            <div class="main">
+                {{ block "main" . }}{{ end }}
+            </div>
+            <div class="side">
+                {{ partial "side-calendar.html" . }}
+                {{ partial "side-door-status.html" . }}
+                {{ partial "side-contact.html" . }}
+            </div>
+        </main>
+        {{ partial "footer.html" . }}
+        {{ partial "html-end.html" . }}
+    </body>
+</html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,72 @@
+{{/*
+    Header mit Sprachschalter zwischen Standard-Sprache und Leichter Sprache.
+    Wenn die aktuelle Seite keine Übersetzung hat, verweist der Schalter auf
+    die Startseite der jeweils anderen Sprache.
+*/}}
+
+{{ $currentLang := .Lang }}
+{{ $altLang := cond (eq $currentLang "de-leicht") "de" "de-leicht" }}
+
+{{ $altURL := "" }}
+{{ $altIsHome := true }}
+{{ range .Translations }}
+    {{ if eq .Lang $altLang }}
+        {{ $altURL = .RelPermalink }}
+        {{ $altIsHome = false }}
+    {{ end }}
+{{ end }}
+{{ if not $altURL }}
+    {{ range .Sites }}
+        {{ if eq .Language.Lang $altLang }}
+            {{ $altURL = .Home.RelPermalink }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+{{ $altLabel := cond (eq $altLang "de-leicht") "Leichte Sprache" "Standard-Sprache" }}
+{{ $altTitle := cond (eq $altLang "de-leicht")
+    "Zur Version dieser Seite in Leichter Sprache wechseln"
+    "Zur Version dieser Seite in Standard-Sprache wechseln" }}
+{{ if $altIsHome }}
+    {{ $altTitle = cond (eq $altLang "de-leicht")
+        "Diese Seite gibt es noch nicht in Leichter Sprache. Zur Startseite in Leichter Sprache wechseln."
+        "Zur Startseite in Standard-Sprache wechseln." }}
+{{ end }}
+
+<header class="header-wrapper">
+    <div class="header">
+        <a class="site-title" href="{{ .Site.Home.RelPermalink }}">Home</a>
+
+        <nav class="menu">
+            {{ range .Site.Menus.main }}
+                <div class="menu-item">
+                    {{ if not .Children }}
+                        <a href="{{ .URL }}">{{ .Name }}</a>
+                    {{ else }}
+                        <a>{{ .Name }}↓</a>
+                        <nav class="sub-menu">
+                            {{ range .Children }}
+                            <div class="menu-item"><a href="{{ .URL }}">{{ .Name }}</a></div>
+                            {{ end }}
+                        </nav>
+                    {{ end }}
+                </div>
+            {{ end }}
+
+            <div class="menu-item lang-switch">
+                <a href="{{ $altURL }}"
+                   class="lang-switch-link{{ if $altIsHome }} lang-switch-fallback{{ end }}"
+                   hreflang="de"
+                   title="{{ $altTitle }}"
+                   aria-label="{{ $altTitle }}">
+                    {{ if eq $altLang "de-leicht" }}
+                        <span class="lang-switch-icon" aria-hidden="true">A</span>
+                    {{ else }}
+                        <span class="lang-switch-icon" aria-hidden="true">Aa</span>
+                    {{ end }}
+                    <span class="lang-switch-label">{{ $altLabel }}</span>
+                </a>
+            </div>
+        </nav>
+    </div>
+</header>

--- a/layouts/partials/html-end.html
+++ b/layouts/partials/html-end.html
@@ -1,0 +1,6 @@
+
+
+<link rel="stylesheet" href="{{ "lib/icofont/icofont.min.css" | relURL }}" />
+<link rel="stylesheet" href="{{ "css/syntax.css" | relURL }}" />
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}" />
+<link rel="stylesheet" href="{{ "css/accessibility.css" | relURL }}" />

--- a/static/css/accessibility.css
+++ b/static/css/accessibility.css
@@ -1,0 +1,101 @@
+/* ------------------------------------------------------------------------- */
+/* Sprachschalter (Standard / Leichte Sprache) im Header.                    */
+/* Sichtbar auf allen Seiten, Tastatur-zugänglich, ausreichende Kontraste.   */
+/* ------------------------------------------------------------------------- */
+
+.header .menu-item.lang-switch {
+    margin-left: auto;
+}
+
+.header .lang-switch-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--len-2);
+
+    padding: var(--len-1) var(--len-3);
+    border: 2px solid var(--color-dark-fg-hyperlink);
+    border-radius: 999px;
+
+    background-color: rgba(0, 0, 0, 0.45);
+    color: var(--color-dark-fg-font-normal);
+
+    font-family: var(--fonts-sans);
+    font-size: var(--font-size-1);
+    font-weight: bold;
+    text-decoration: none;
+
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.header .lang-switch-link:hover,
+.header .lang-switch-link:focus {
+    background-color: var(--color-dark-fg-hyperlink);
+    color: #0d0d0d;
+    border-color: var(--color-dark-fg-hyperlink);
+    outline: none;
+    text-shadow: none;
+}
+
+.header .lang-switch-link:focus-visible {
+    outline: 3px solid #ffffff;
+    outline-offset: 2px;
+}
+
+.header .lang-switch-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    min-width: 1.6em;
+    height: 1.6em;
+    padding: 0 0.35em;
+    border-radius: 50%;
+
+    background-color: var(--color-dark-fg-hyperlink);
+    color: #0d0d0d;
+
+    font-family: var(--fonts-sans);
+    font-size: var(--font-size-1);
+    font-weight: bold;
+    line-height: 1;
+    text-shadow: none;
+}
+
+.header .lang-switch-link:hover .lang-switch-icon,
+.header .lang-switch-link:focus .lang-switch-icon {
+    background-color: #0d0d0d;
+    color: var(--color-dark-fg-hyperlink);
+}
+
+/* Auf mobilen Layouts klappt das Hauptmenü um. Der Sprachschalter steht
+   dort sinnvollerweise links statt rechts. */
+@media (max-width: 767px) {
+    .header .menu-item.lang-switch {
+        margin-left: 0;
+    }
+}
+
+/* ------------------------------------------------------------------------- */
+/* Hinweis-Banner auf Seiten in Leichter Sprache, wenn keine Übersetzung    */
+/* der konkreten Unterseite vorhanden ist und auf die Startseite verwiesen  */
+/* wird.                                                                    */
+/* ------------------------------------------------------------------------- */
+
+.leichte-sprache-hinweis {
+    margin: 0 0 var(--len-4) 0;
+    padding: var(--len-3) var(--len-4);
+    border-left: 4px solid var(--color-dark-fg-hyperlink);
+    border-radius: 4px;
+
+    background-color: var(--color-bg-block);
+    color: var(--color-fg-font-normal);
+
+    font-family: var(--fonts-sans);
+    font-size: var(--font-size-2);
+    line-height: 1.5;
+}
+
+.leichte-sprache-hinweis strong {
+    display: block;
+    margin-bottom: var(--len-1);
+}


### PR DESCRIPTION
Damit die Webseite auch für Menschen mit Lern-Schwierigkeiten, geringen Deutsch-Kenntnissen oder Lese-Schwierigkeiten erreichbar ist (BFSG / EAA-Vorgaben), gibt es jetzt parallel zur Standard-Sprache eine Version in Leichter Sprache unter /de-leicht/.

- Hugo Multilingual-Setup: Standard "de" am Root, "de-leicht" unter /de-leicht/
- Sprachschalter (Pille mit "A" / "Aa") oben rechts im Header, auf jeder Seite sichtbar, Tastatur- und Screenreader-tauglich
- Fällt auf die Startseite in Leichter Sprache zurück, wenn eine Unterseite (noch) keine Übersetzung hat
- Erste Übersetzungen: Startseite, Über uns/Philosophie, Kontakt
- Eigenes Menü für Leichte Sprache (nur Seiten mit existierender Übersetzung)